### PR TITLE
Short syntax for Ternary Operator

### DIFF
--- a/index.php
+++ b/index.php
@@ -18,6 +18,6 @@ file_exists('theme/functions.php') and require 'theme/functions.php';
 ob_start() and $data = require $file;
 $content = ob_get_clean();
 
-extract($data ? $data : array());
+extract($data ?: array());
 
 include 'theme/layout.php';


### PR DESCRIPTION
Cause 8-cms requires php 5.3 we can use [short syntax](http://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary)
